### PR TITLE
avoiding catch 22 - removing prerequisites from setup

### DIFF
--- a/tasty_bytes_dbt_demo/setup/tasty_bytes_setup.sql
+++ b/tasty_bytes_dbt_demo/setup/tasty_bytes_setup.sql
@@ -1,13 +1,9 @@
 USE ROLE accountadmin;
-
-CREATE OR REPLACE DATABASE tasty_bytes_dbt_db; -- target
-CREATE OR REPLACE SCHEMA tasty_bytes_dbt_db.integrations; -- API Integration and External Access Integration
+USE WAREHOUSE tasty_bytes_dbt_wh;
 
 CREATE OR REPLACE DATABASE tb_101; -- source
 CREATE OR REPLACE SCHEMA tb_101.raw;
 
-CREATE OR REPLACE WAREHOUSE tasty_bytes_dbt_wh
-WAREHOUSE_SIZE = 'XLARGE';
 
 CREATE OR REPLACE FILE FORMAT tb_101.public.csv_ff 
 type = 'csv';


### PR DESCRIPTION
This is a patch PR that removes prerequisites that are generally needed before we run the set up script. 

We realized as we were walking through the tutorial there are some gotchas and users need to have a database.integrations schema created before actually running the setup script.