### PR TITLE
Align setup script with getting-started tutorial and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,39 @@
-# Getting Started with dbt on Snowflake
+# Getting Started with dbt Projects on Snowflake
 
 ## Overview
 
-This repository contains an example dbt project to get you started with dbt on Snowflake. 
+This repository contains an example dbt project for [dbt Projects on Snowflake](https://docs.snowflake.com/en/user-guide/data-engineering/dbt-projects-on-snowflake). It uses the fictitious **Tasty Bytes** food truck brand as sample data and walks through environment setup, data modeling, CI/CD, and scheduling — all running natively inside Snowflake.
+
+This repository is based on these Snowflake tutorials:
+- [Get started with dbt Projects on Snowflake](https://docs.snowflake.com/en/user-guide/tutorials/dbt-projects-on-snowflake-getting-started-tutorial)
+- [Set up CI/CD for dbt Projects on Snowflake](https://docs.snowflake.com/en/user-guide/tutorials/dbt-projects-on-snowflake-ci-cd-tutorial)
+
+## What's Included
+
+### Setup Scripts (`setup/`)
+
+- **`tasty_bytes_setup.sql`** — Creates the warehouse, database, schemas, GitHub integration, network rules, and loads the Tasty Bytes source data from S3 into raw tables.
+- **`ci_cd_setup.sql`** — Creates a GitHub Actions service user with OIDC authentication and optional network policies for CI/CD pipelines.
+
+### dbt Project (`tasty_bytes_dbt_demo/`)
+
+- **Staging models** — Views that clean and rename columns from raw source tables (orders, trucks, menus, locations, franchises, customer loyalty).
+- **Mart models** — Tables that aggregate business metrics: `orders`, `customer_loyalty_metrics`, and `sales_metrics_by_location` (Python model).
+- **Custom macros** — Schema name generation for multi-environment deployments (dev/prod).
+- **Generic tests** — Reusable test for validating positive amounts.
+
+### CI/CD (`.github/workflows/`)
+
+- **`incoming_pr.yml`** — Runs dbt checks against a dev environment when a PR is opened.
+- **`pr_merged.yml`** — Deploys the dbt project to production when a PR is merged.
+
+### Scheduling (`schedules.sql`)
+
+Task definitions for running the dbt project on a schedule using Snowflake Tasks.
+
+## Quick Start
+
+1. Fork this repository.
+2. Run `tasty_bytes_setup.sql` in a Snowflake worksheet to create the environment and load source data.
+3. Create a [workspace in Snowsight](https://docs.snowflake.com/en/user-guide/ui-snowsight/workspaces) connected to your fork.
+4. Run `dbt deps`, then `dbt run` from the workspace.

--- a/tasty_bytes_dbt_demo/setup/tasty_bytes_setup.sql
+++ b/tasty_bytes_dbt_demo/setup/tasty_bytes_setup.sql
@@ -1,20 +1,57 @@
+-- =============================================================================
+-- Tasty Bytes dbt Demo: Environment Setup & Source Data
+-- Source: https://docs.snowflake.com/en/user-guide/tutorials/dbt-projects-on-snowflake-getting-started-tutorial
+--
+-- This script sets up the complete environment for the Tasty Bytes dbt project:
+--   1. Warehouse for executing workspace actions
+--   2. Database and schemas for integrations and model materializations
+--   3. Logging, tracing, and metrics for observability
+--   4. GitHub secret and API integration for connecting to your repository
+--   5. Network rule and external access integration for dbt dependencies
+--   6. Source data: Tasty Bytes foundational data model (raw zone tables + data load)
+--
+-- NOTE: Before running this script in a workspace, comment out any CREATE statements
+-- for objects you already created during the "Set up your environment" steps:
+--   CREATE OR REPLACE WAREHOUSE ...
+--   CREATE OR REPLACE API INTEGRATION ...
+--   CREATE OR REPLACE NETWORK RULE ...
+--   CREATE OR REPLACE EXTERNAL ACCESS INTEGRATION ...
+-- =============================================================================
+
 USE ROLE accountadmin;
 
-CREATE OR REPLACE WAREHOUSE tasty_bytes_dbt_wh
-    WAREHOUSE_SIZE = 'small'
-    WAREHOUSE_TYPE = 'standard'
-    AUTO_SUSPEND = 60
-    AUTO_RESUME = TRUE
-    INITIALLY_SUSPENDED = TRUE
-    COMMENT = 'warehouse for tasty bytes dbt demo';
+-- =============================================================================
+-- STEP 1: Create a warehouse for executing workspace actions
+-- A dedicated warehouse assigned to your workspace helps you log, trace,
+-- and identify actions initiated from within that workspace.
+-- The Tasty Bytes data model is fairly large, so an XL warehouse is recommended.
+-- Alternatively, you can use an existing warehouse in your account.
+-- =============================================================================
 
-USE WAREHOUSE tasty_bytes_dbt_wh;
+CREATE WAREHOUSE tasty_bytes_dbt_wh WAREHOUSE_SIZE = XLARGE;
+
+-- =============================================================================
+-- STEP 2: Create a database and schemas for integrations and model materializations
+-- The INTEGRATIONS schema stores objects Snowflake needs for GitHub integration.
+-- The DEV and PROD schemas store materialized objects that your dbt project creates.
+-- The RAW schema holds the Tasty Bytes foundational source data.
+-- =============================================================================
 
 CREATE DATABASE IF NOT EXISTS tasty_bytes_dbt_db;
-CREATE OR REPLACE SCHEMA tasty_bytes_dbt_db.raw;
-CREATE OR REPLACE SCHEMA tasty_bytes_dbt_db.dev;
-CREATE OR REPLACE SCHEMA tasty_bytes_dbt_db.prod;
+CREATE SCHEMA IF NOT EXISTS tasty_bytes_dbt_db.dev;
+CREATE SCHEMA IF NOT EXISTS tasty_bytes_dbt_db.prod;
+-- Used for storing objects Snowflake needs for GitHub integration (secrets, etc.)
+CREATE SCHEMA IF NOT EXISTS tasty_bytes_dbt_db.integrations;
+-- Used for the Tasty Bytes foundational source data loaded from S3
+CREATE SCHEMA IF NOT EXISTS tasty_bytes_dbt_db.raw;
 
+-- =============================================================================
+-- STEP 3: Enable logging, tracing, and metrics
+-- You can capture logging and tracing events for a dbt project object and for
+-- the task that runs it on a schedule. These settings must be applied to the
+-- schemas where the dbt project object and task are deployed.
+-- See: https://docs.snowflake.com/en/user-guide/data-engineering/dbt-projects-on-snowflake-monitoring-observability
+-- =============================================================================
 
 ALTER SCHEMA tasty_bytes_dbt_db.dev SET LOG_LEVEL = 'INFO';
 ALTER SCHEMA tasty_bytes_dbt_db.dev SET TRACE_LEVEL = 'ALWAYS';
@@ -24,10 +61,67 @@ ALTER SCHEMA tasty_bytes_dbt_db.prod SET LOG_LEVEL = 'INFO';
 ALTER SCHEMA tasty_bytes_dbt_db.prod SET TRACE_LEVEL = 'ALWAYS';
 ALTER SCHEMA tasty_bytes_dbt_db.prod SET METRIC_LEVEL = 'ALL';
 
-CREATE OR REPLACE API INTEGRATION git_integration
+-- =============================================================================
+-- STEP 4: Create a GitHub secret and API integration
+-- Snowflake needs an API integration to interact with GitHub.
+-- If your repository is private, you must also create a secret to store GitHub
+-- credentials. You then reference the secret in the API integration definition
+-- and when creating the workspace for your dbt project.
+--
+-- Creating a secret requires a personal access token for your repository.
+-- See: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
+-- =============================================================================
+
+USE tasty_bytes_dbt_db.integrations;
+CREATE OR REPLACE SECRET tasty_bytes_dbt_db.integrations.tb_dbt_git_secret
+  TYPE = password
+  USERNAME = 'your-gh-username'
+  PASSWORD = 'YOUR_PERSONAL_ACCESS_TOKEN';
+
+-- Replace 'https://github.com/my-github-account' with the URL of the GitHub
+-- account for your forked repository.
+-- This API integration is used when creating a workspace in Snowsight (Projects > Workspaces)
+-- to connect Snowflake to your forked GitHub repository.
+CREATE OR REPLACE API INTEGRATION tasty_bytes_dbt_db.integrations.tb_dbt_git_api_integration
   API_PROVIDER = git_https_api
-  API_ALLOWED_PREFIXES = ('https://github.com/')
+  API_ALLOWED_PREFIXES = ('https://github.com/my-github-account')
+  -- Comment out the following line if your forked repository is public
+  ALLOWED_AUTHENTICATION_SECRETS = (tasty_bytes_dbt_db.integrations.tb_dbt_git_secret)
   ENABLED = TRUE;
+
+-- =============================================================================
+-- STEP 5: (Optional) Create a network rule and external access integration
+-- When you run dbt commands in a workspace, dbt might need to access remote
+-- URLs to download dependencies (e.g. packages from the dbt Package hub or
+-- from GitHub). Most dbt projects specify dependencies in their packages.yml
+-- file, which must be installed in the workspace before other commands will work.
+-- See: https://docs.snowflake.com/en/developer-guide/external-network-access/creating-using-external-network-access
+-- =============================================================================
+
+-- Create NETWORK RULE for external access integration
+CREATE OR REPLACE NETWORK RULE dbt_network_rule
+  MODE = EGRESS
+  TYPE = HOST_PORT
+  -- Minimal URL allowlist that is required for dbt deps
+  VALUE_LIST = (
+    'hub.getdbt.com',
+    'codeload.github.com'
+    );
+
+-- Create EXTERNAL ACCESS INTEGRATION for dbt access to external dbt package locations
+CREATE OR REPLACE EXTERNAL ACCESS INTEGRATION dbt_ext_access
+  ALLOWED_NETWORK_RULES = (dbt_network_rule)
+  ENABLED = TRUE;
+
+-- =============================================================================
+-- STEP 6: Set up source data - Tasty Bytes foundational data model
+-- The dbt project uses the foundational data model for the fictitious Tasty Bytes
+-- food truck brand as its source data for transformations.
+-- This section creates a file format and external stage pointing to S3, builds
+-- the raw zone tables, and loads data into them.
+-- =============================================================================
+
+---- File format and external stage ----
 
 CREATE OR REPLACE FILE FORMAT tasty_bytes_dbt_db.public.csv_ff 
 type = 'csv';
@@ -37,9 +131,9 @@ COMMENT = 'Quickstarts S3 Stage Connection'
 url = 's3://sfquickstarts/frostbyte_tastybytes/'
 file_format = tasty_bytes_dbt_db.public.csv_ff;
 
-/*--
- raw zone table build 
---*/
+-- =============================================================================
+--  Raw zone table builds
+-- =============================================================================
 
 -- country table build
 CREATE OR REPLACE TABLE tasty_bytes_dbt_db.raw.country
@@ -97,7 +191,7 @@ CREATE OR REPLACE TABLE tasty_bytes_dbt_db.raw.menu
 )
 COMMENT = '{"origin":"sf_sit-is", "name":"tasty-bytes-dbt", "version":{"major":1, "minor":0}, "attributes":{"is_quickstart":1, "source":"sql"}}';
 
--- truck table build 
+-- truck table build
 CREATE OR REPLACE TABLE tasty_bytes_dbt_db.raw.truck
 (
     truck_id NUMBER(38,0),
@@ -154,7 +248,7 @@ CREATE OR REPLACE TABLE tasty_bytes_dbt_db.raw.order_detail
 )
 COMMENT = '{"origin":"sf_sit-is", "name":"tasty-bytes-dbt", "version":{"major":1, "minor":0}, "attributes":{"is_quickstart":1, "source":"sql"}}';
 
--- customer loyalty table build
+-- customer_loyalty table build
 CREATE OR REPLACE TABLE tasty_bytes_dbt_db.raw.customer_loyalty
 (
     customer_id NUMBER(38,0),
@@ -175,9 +269,9 @@ CREATE OR REPLACE TABLE tasty_bytes_dbt_db.raw.customer_loyalty
 )
 COMMENT = '{"origin":"sf_sit-is", "name":"tasty-bytes-dbt", "version":{"major":1, "minor":0}, "attributes":{"is_quickstart":1, "source":"sql"}}';
 
-/*--
- raw zone table load 
---*/
+-- =============================================================================
+--  Raw zone data loads from S3 stage
+-- =============================================================================
 
 -- country table load
 COPY INTO tasty_bytes_dbt_db.raw.country
@@ -211,5 +305,8 @@ FROM @tasty_bytes_dbt_db.public.s3load/raw_pos/order_header/;
 COPY INTO tasty_bytes_dbt_db.raw.order_detail
 FROM @tasty_bytes_dbt_db.public.s3load/raw_pos/order_detail/;
 
--- setup completion note
+-- =============================================================================
+-- Setup complete
+-- =============================================================================
+
 SELECT 'tasty_bytes_dbt_db setup is now complete' AS note;

--- a/tasty_bytes_dbt_demo/setup/tasty_bytes_setup.sql
+++ b/tasty_bytes_dbt_demo/setup/tasty_bytes_setup.sql
@@ -18,7 +18,7 @@
 --   CREATE OR REPLACE EXTERNAL ACCESS INTEGRATION ...
 -- =============================================================================
 
-USE ROLE accountadmin;
+USE ROLE ACCOUNTADMIN;
 
 -- =============================================================================
 -- STEP 1: Create a warehouse for executing workspace actions

--- a/tasty_bytes_dbt_demo/setup/tasty_bytes_setup.sql
+++ b/tasty_bytes_dbt_demo/setup/tasty_bytes_setup.sql
@@ -70,6 +70,9 @@ ALTER SCHEMA tasty_bytes_dbt_db.prod SET METRIC_LEVEL = 'ALL';
 --
 -- Creating a secret requires a personal access token for your repository.
 -- See: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
+--
+-- Alternatively, your admin can set up one OAuth2 integration for the team instead of managing personal access tokens.
+-- See: https://docs.snowflake.com/en/user-guide/ui-snowsight/workspaces-git
 -- =============================================================================
 
 USE tasty_bytes_dbt_db.integrations;
@@ -82,7 +85,7 @@ CREATE OR REPLACE SECRET tasty_bytes_dbt_db.integrations.tb_dbt_git_secret
 -- account for your forked repository.
 -- This API integration is used when creating a workspace in Snowsight (Projects > Workspaces)
 -- to connect Snowflake to your forked GitHub repository.
-CREATE OR REPLACE API INTEGRATION tasty_bytes_dbt_db.integrations.tb_dbt_git_api_integration
+CREATE OR REPLACE API INTEGRATION tb_dbt_git_api_integration
   API_PROVIDER = git_https_api
   API_ALLOWED_PREFIXES = ('https://github.com/my-github-account')
   -- Comment out the following line if your forked repository is public
@@ -91,27 +94,27 @@ CREATE OR REPLACE API INTEGRATION tasty_bytes_dbt_db.integrations.tb_dbt_git_api
 
 -- =============================================================================
 -- STEP 5: (Optional) Create a network rule and external access integration
--- When you run dbt commands in a workspace, dbt might need to access remote
--- URLs to download dependencies (e.g. packages from the dbt Package hub or
+-- If you plan to run 'dbt deps' in a workspace, dbt will need to access remote
+-- URLs to download dependencies (e.g. packages from the dbt Package Hub or
 -- from GitHub). Most dbt projects specify dependencies in their packages.yml
 -- file, which must be installed in the workspace before other commands will work.
 -- See: https://docs.snowflake.com/en/developer-guide/external-network-access/creating-using-external-network-access
 -- =============================================================================
 
 -- Create NETWORK RULE for external access integration
-CREATE OR REPLACE NETWORK RULE dbt_network_rule
-  MODE = EGRESS
-  TYPE = HOST_PORT
-  -- Minimal URL allowlist that is required for dbt deps
-  VALUE_LIST = (
-    'hub.getdbt.com',
-    'codeload.github.com'
-    );
+-- CREATE OR REPLACE NETWORK RULE dbt_network_rule
+--   MODE = EGRESS
+--   TYPE = HOST_PORT
+--   -- Minimal URL allowlist that is required for dbt deps
+--   VALUE_LIST = (
+--     'hub.getdbt.com',
+--     'codeload.github.com'
+--     );
 
 -- Create EXTERNAL ACCESS INTEGRATION for dbt access to external dbt package locations
-CREATE OR REPLACE EXTERNAL ACCESS INTEGRATION dbt_ext_access
-  ALLOWED_NETWORK_RULES = (dbt_network_rule)
-  ENABLED = TRUE;
+-- CREATE OR REPLACE EXTERNAL ACCESS INTEGRATION dbt_ext_access
+--   ALLOWED_NETWORK_RULES = (dbt_network_rule)
+--   ENABLED = TRUE;
 
 -- =============================================================================
 -- STEP 6: Set up source data - Tasty Bytes foundational data model
@@ -121,7 +124,7 @@ CREATE OR REPLACE EXTERNAL ACCESS INTEGRATION dbt_ext_access
 -- the raw zone tables, and loads data into them.
 -- =============================================================================
 
----- File format and external stage ----
+-- File format and external stage
 
 CREATE OR REPLACE FILE FORMAT tasty_bytes_dbt_db.public.csv_ff 
 type = 'csv';


### PR DESCRIPTION
## Summary

- Adds missing SQL from the Snowflake "Set up your environment" tutorial steps to `tasty_bytes_setup.sql`: `integrations` schema, GitHub secret, API integration with private repo support, network rule, and external access integration.
- Replaces the old minimal `git_integration` with the tutorial's `tb_dbt_git_api_integration`, including `ALLOWED_AUTHENTICATION_SECRETS` for private repos.
- Updates warehouse creation to match the tutorial (`WAREHOUSE_SIZE = XLARGE`).
- Restructures the setup script with numbered step headers, descriptive commentary, and doc links (matching the style in `ci_cd_setup.sql`).
- Rewrites `README.md` with a concise overview of the repo: setup scripts, dbt project, CI/CD workflows, scheduling, and a quick start guide.

## Test plan

- [ ] Verify `tasty_bytes_setup.sql` runs end-to-end on a clean Snowflake account
- [ ] Confirm placeholder values (`your-gh-username`, `YOUR_PERSONAL_ACCESS_TOKEN`, `my-github-account`) are clearly identifiable as needing replacement
- [ ] Review README for accuracy against current repo contents